### PR TITLE
Enhancement: Better error transpirancy in ParseError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub use crate::token::{Key, KeyAttribute, KeyRepr, Modifier, ModifierRepr};
 
 #[derive(Debug, Error)]
 pub enum ParseError {
-    #[error("unable to parse config file")]
+    #[error("\n{0}\nUnable to parse config file")]
     // pest::error::Error being 184 bytes makes this entire enum
     // expensive to copy, hence the box is used to put it on the heap.
     Grammar(#[from] Box<pest::error::Error<Rule>>),


### PR DESCRIPTION
# Adds better transparency to ParseError::Grammar 
Allows for ParseError::Grammar to contain more helpful context from pest error