### PR TITLE
deps: prune nix flake by not evaluating darwin derivations

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,54 +1,24 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-NLznXB5AOnniUtZsyy/aPWOk8ussTuePp2acb9U+ISA=",
-        "path": "/nix/store/3kwj19dbdfxnjbcns4hw307ylhz3wgrm-source",
-        "type": "path"
+        "lastModified": 1742422364,
+        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
+        "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,27 +1,25 @@
 {
-  description = "devshell for github:lavafroth/sweet";
-
-  inputs.flake-utils.url = "github:numtide/flake-utils";
+  description = "devshell for github:waycrate/sweet";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
   outputs =
+    { nixpkgs, ... }:
+    let
+      forAllSystems =
+        function:
+        nixpkgs.lib.genAttrs [
+          # leaving out darwin as it cannot run wayland
+          "x86_64-linux"
+          "aarch64-linux"
+        ] (system: function nixpkgs.legacyPackages.${system});
+    in
     {
-      self,
-      nixpkgs,
-      flake-utils,
-    }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-      in
-      {
-        devShells.default = pkgs.mkShell rec {
-          packages = with pkgs; [
-            stdenv.cc.cc.lib
-          ];
-
-          LD_LIBRARY_PATH = "${nixpkgs.lib.makeLibraryPath packages}";
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = [ pkgs.stdenv.cc.cc ];
+          LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib ]}";
         };
-      }
-    );
+      });
+    };
+
 }

--- a/flake.nix
+++ b/flake.nix
@@ -5,19 +5,18 @@
   outputs =
     { nixpkgs, ... }:
     let
-      forAllSystems =
-        function:
-        nixpkgs.lib.genAttrs [
-          # leaving out darwin as it cannot run wayland
-          "x86_64-linux"
-          "aarch64-linux"
-        ] (system: function nixpkgs.legacyPackages.${system});
+      # leaving out darwin as it cannot run wayland
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
     in
     {
       devShells = forAllSystems (pkgs: {
         default = pkgs.mkShell {
           packages = [ pkgs.stdenv.cc.cc ];
-          LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib ]}";
+          LD_LIBRARY_PATH = pkgs.stdenv.cc.cc.LIBRARY_PATH;
         };
       });
     };


### PR DESCRIPTION
### Changes
- Remove `flake-utils` inputs
- Roll out `forAllSystems` function which omits darwin (macos) derivations since it can't run wayland
- Use predefined `stdenv.cc.cc.LIBRARY_PATH` for `LD_LIBRARY_PATH` environment variable